### PR TITLE
Fix reference to saved customer ID

### DIFF
--- a/customized-checkout/customers/python/add_card.py
+++ b/customized-checkout/customers/python/add_card.py
@@ -7,7 +7,7 @@ customer = {
 }
 
 saved_customer = mp.get ("/v1/customers/search", customer);
-customer_id = saved_customer["response"]["id"];
+customer_id = saved_customer["response"]["results"][0]["id"];
 
 card = mp.post ("/v1/customers/"+customer_id+"/cards", {"token": "ff8080814c11e237014c1ff593b57b4d"})
 


### PR DESCRIPTION
The /search endpoint response doesn't match with this code. To get the ID you have to go to the first element on the results, it have pagination now.